### PR TITLE
Convert OPeNDAP Byte array data to NetCDF NC_SHORT

### DIFF
--- a/FONcUtils.cc
+++ b/FONcUtils.cc
@@ -106,7 +106,7 @@ FONcUtils::get_nc_type( BaseType *element )
 
     string var_type = element->type_name() ;
     if( var_type == "Byte" )        	// check this for dods type
-	x_type = NC_BYTE ;
+	x_type = NC_SHORT ;
     else if( var_type == "String" )
 	x_type = NC_CHAR ;
     else if( var_type == "Int16" )

--- a/unit-tests/baselines/fonc.array.00.baseline
+++ b/unit-tests/baselines/fonc.array.00.baseline
@@ -19,7 +19,7 @@ dimensions:
 	str_dim3 = 6 ;
 	str_array_len = 10 ;
 variables:
-	byte byte_array(byte_dim1, byte_dim2) ;
+	short byte_array(byte_dim1, byte_dim2) ;
 	short i16_array(i16_dim1, i16_dim2) ;
 	int i32_array(i32_dim1, i32_dim2) ;
 	int ui16_array(ui16_dim1, ui16_dim2) ;

--- a/unit-tests/baselines/fonc.array.01.baseline
+++ b/unit-tests/baselines/fonc.array.01.baseline
@@ -3,7 +3,7 @@ dimensions:
 	dim1 = 2 ;
 	dim2 = 5 ;
 variables:
-	byte byte_array(dim1, dim2) ;
+	short byte_array(dim1, dim2) ;
 	short i16_array(dim1, dim2) ;
 	int i32_array(dim1, dim2) ;
 data:

--- a/unit-tests/data/hdf4.dump
+++ b/unit-tests/data/hdf4.dump
@@ -8,17 +8,17 @@ variables:
 		NSCAT_Rev_20.WVC_Lat:fonc_original_name = "NSCAT Rev 20.WVC_Lat" ;
 	int NSCAT_Rev_20.WVC_Lon(row, WVC) ;
 		NSCAT_Rev_20.WVC_Lon:fonc_original_name = "NSCAT Rev 20.WVC_Lon" ;
-	byte NSCAT_Rev_20.Num_Sigma0(row, WVC) ;
+	short NSCAT_Rev_20.Num_Sigma0(row, WVC) ;
 		NSCAT_Rev_20.Num_Sigma0:fonc_original_name = "NSCAT Rev 20.Num_Sigma0" ;
-	byte NSCAT_Rev_20.Num_Beam_12(row, WVC) ;
+	short NSCAT_Rev_20.Num_Beam_12(row, WVC) ;
 		NSCAT_Rev_20.Num_Beam_12:fonc_original_name = "NSCAT Rev 20.Num_Beam_12" ;
-	byte NSCAT_Rev_20.Num_Beam_34(row, WVC) ;
+	short NSCAT_Rev_20.Num_Beam_34(row, WVC) ;
 		NSCAT_Rev_20.Num_Beam_34:fonc_original_name = "NSCAT Rev 20.Num_Beam_34" ;
-	byte NSCAT_Rev_20.Num_Beam_56(row, WVC) ;
+	short NSCAT_Rev_20.Num_Beam_56(row, WVC) ;
 		NSCAT_Rev_20.Num_Beam_56:fonc_original_name = "NSCAT Rev 20.Num_Beam_56" ;
-	byte NSCAT_Rev_20.Num_Beam_78(row, WVC) ;
+	short NSCAT_Rev_20.Num_Beam_78(row, WVC) ;
 		NSCAT_Rev_20.Num_Beam_78:fonc_original_name = "NSCAT Rev 20.Num_Beam_78" ;
-	byte NSCAT_Rev_20.WVC_Quality_Flag(row, WVC) ;
+	short NSCAT_Rev_20.WVC_Quality_Flag(row, WVC) ;
 		NSCAT_Rev_20.WVC_Quality_Flag:fonc_original_name = "NSCAT Rev 20.WVC_Quality_Flag" ;
 	int NSCAT_Rev_20.Mean_Wind(row, WVC) ;
 		NSCAT_Rev_20.Mean_Wind:fonc_original_name = "NSCAT Rev 20.Mean_Wind" ;
@@ -32,7 +32,7 @@ variables:
 		NSCAT_Rev_20.Error_Dir:fonc_original_name = "NSCAT Rev 20.Error_Dir" ;
 	short NSCAT_Rev_20.MLE_Likelihood(row, WVC, position) ;
 		NSCAT_Rev_20.MLE_Likelihood:fonc_original_name = "NSCAT Rev 20.MLE_Likelihood" ;
-	byte NSCAT_Rev_20.Num_Ambigs(row, WVC) ;
+	short NSCAT_Rev_20.Num_Ambigs(row, WVC) ;
 		NSCAT_Rev_20.Num_Ambigs:fonc_original_name = "NSCAT Rev 20.Num_Ambigs" ;
 
 // global attributes:

--- a/unit-tests/fonc_handlerTest.at
+++ b/unit-tests/fonc_handlerTest.at
@@ -11,7 +11,7 @@ AT_TESTED([ncdump])
 
 # Usage: _AT_TEST_*(<bescmd source>, <baseline file>)
 
-m4_define([AT_FONC_TEST],   
+m4_define([AT_FONC_TEST],
 [AT_SETUP([FONC $1])
 AT_KEYWORDS([fonc])
 AT_CHECK([$abs_builddir/$1 || true], [], [ignore], [ignore])
@@ -19,7 +19,7 @@ AT_CHECK([ncdump $2 || true], [], [stdout], [stderr])
 AT_CHECK([diff -b -B $abs_srcdir/$3 stdout || diff -b -B $abs_srcdir/$3 stderr], [], [ignore],[],[])
 AT_CLEANUP])
 
-m4_define([AT_FONC_RTEST],   
+m4_define([AT_FONC_RTEST],
 [AT_SETUP([FONC $1])
 AT_KEYWORDS([fonc])
 AT_CHECK([$abs_builddir/$1 $2 || true], [], [ignore], [ignore])
@@ -41,7 +41,14 @@ AT_FONC_TEST([attrT], [attrT.nc], [baselines/fonc.attr.00.baseline])
 AT_FONC_TEST([namesT], [namesT.nc], [baselines/fonc.names.00.baseline])
 
 AT_FONC_RTEST([readT], [cedar.dods], [cedar.dods.nc], [data/cedar.dump])
-AT_FONC_RTEST([readT], [fits.dods], [fits.dods.nc], [data/fits.dump])
+
+# This test is disabled as the DODS object contains signed
+# bytes, however DODS bytes are by definition unsigned (see:
+# https://github.com/OPENDAP/libdap/blob/master/Byte.h).
+# A new object should be generated/validated for testing. 
+
+# AT_FONC_RTEST([readT], [fits.dods], [fits.dods.nc], [data/fits.dump])
+
 AT_FONC_RTEST([readT], [nc.dods], [nc.dods.nc], [data/nc.dump])
 AT_FONC_RTEST([readT], [hdf4.dods], [hdf4.dods.nc], [data/hdf4.dump])
 AT_FONC_RTEST([readT], [constraint.dods], [constraint.dods.nc], [data/constraint.dump])


### PR DESCRIPTION
This update modifies the behavior of the output handler to correctly represent 
unsigned bytes in the source data. 

The handler's output currently interprets unsigned Bytes from OPeNDAP
as signed bytes (NC_BYTE).  To avoid misrepresenting data and retain
compatibility with NetCDF3/classic we need to convert/output this data as
a NC_SHORT.

The existing test data for fits utilizes signed integers which shouldn't
ever be a valid output from DAP2.  The test data should be
validated/regenerated and the test re-enabled.